### PR TITLE
Fixing file assertion

### DIFF
--- a/craftsman/pipeline.py
+++ b/craftsman/pipeline.py
@@ -83,7 +83,7 @@ class CraftsManPipeline():
         """
         if isinstance(image, str):
             assert os.path.isfile(image) or image.startswith("http"), "Input image must be a valid URL or a file path."
-        elif isinstance(image, (torch.Tensor, PIL.Image.Image)):
+        elif not isinstance(image, (torch.Tensor, PIL.Image.Image)):
             raise ValueError("Input image must be a `torch.Tensor` or `PIL.Image.Image`.")
         
     def preprocess_image(


### PR DESCRIPTION
Currently, you check if the input is a string URL to an image or if it is torch.Tensor or PIL.Image.Image. If it is torch.Tensor or PIL.Image.Image you raise an error says it should be one of them. I belive this is a mistake, adding not to the term makes it work just fine.